### PR TITLE
Corrigindo layout da tela de login

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -31,7 +31,7 @@ h1, h3 {
 }
 
 .descriptionBox {
-    display: flex;
+    display: none;
 }
 
 /*Desktop layout */


### PR DESCRIPTION
A tela de login estava com um erro de renderização. 
O layout de desktop não era ocultado quando a visualização acontecia em dispositivos menores que 1024px.

Corrigi, mas não cheguei a testar pela questão de ambiente e etc. Pode subir para validarmos?